### PR TITLE
Fixed a NullPointerException in resetAll() when mMediaProjection is null

### DIFF
--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
@@ -487,8 +487,6 @@ public class ScreenRecordService extends Service {
         }
         if (mMediaRecorder != null) {
             mMediaRecorder.setOnErrorListener(null);
-
-            mMediaProjection.stop();
             mMediaRecorder.reset();
         }
         if (mMediaProjection != null) {


### PR DESCRIPTION
I am getting a NullPointerException at this line, and this seems like an obvious fix.
Unless there is a good reason why `mMediaProjection.stop()` is called just before `mMediaRecorder.reset()` (and then again just after that).
Even if it does not fix the underlying issue (of mMediaProjection being null), it should prevent the crash from happening.