### PR TITLE
Updates to allow setting a max file size, begin consolidating constants into a central file, consolidating strings into a strings.xml file

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
     defaultConfig {
         applicationId "com.hbisoft.hbrecorderexample"
         minSdkVersion 17
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
@@ -20,12 +20,12 @@ android {
 
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.legacy:legacy-support-core-utils:1.0.0'
     implementation 'androidx.preference:preference:1.1.1'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
     implementation project(path: ':hbrecorder')
 }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,10 +7,13 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" />
     <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="28"
+        tools:ignore="ScopedStorage" />
 
     <application
-        android:allowBackup="true"
+        android:allowBackup="false"
+        android:fullBackupContent="@xml/backup_descriptor"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
         android:supportsRtl="true"

--- a/app/src/main/res/layout/activity_main.xml
+++ b/app/src/main/res/layout/activity_main.xml
@@ -1,24 +1,50 @@
 <?xml version="1.0" encoding="utf-8"?>
-<RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<RelativeLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:tools="http://schemas.android.com/tools"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     tools:ignore="Overdraw">
 
+    <LinearLayout
+        android:id="@+id/max_filesize_linear_layout"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:orientation="horizontal"
+        android:layout_centerHorizontal="true">
+
+        <EditText
+            android:id="@+id/max_file_size"
+            android:inputType="numberSigned"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:hint="@string/max_file_hint"
+            android:importantForAutofill="no" />
+
+        <TextView
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:text="@string/max_file_label"
+            android:layout_marginTop="10dp"/>
+
+    </LinearLayout>
+
     <ImageView
         android:layout_width="300dp"
         android:layout_height="1dp"
+        android:layout_below="@+id/max_filesize_linear_layout"
         android:layout_centerHorizontal="true"
         android:background="#b1b1b1"
         android:layout_marginTop="40dp"
         android:id="@+id/hl"
-        android:alpha="0.5"/>
+        android:alpha="0.5"
+        tools:ignore="ContentDescription" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="QUICK SETTINGS"
+        android:text="@string/quick_settings_title"
         android:layout_below="@+id/hl"
         android:layout_centerHorizontal="true"
         android:layout_marginTop="20dp"
@@ -61,8 +87,7 @@
         android:layout_marginTop="30dp"
         android:checked="true"
         android:text="@string/record_audio"
-        app:theme="@style/CheckboxStyle"
-        />
+        app:theme="@style/CheckboxStyle"/>
 
     <ImageView
         android:layout_width="300dp"
@@ -72,12 +97,13 @@
         android:background="#b1b1b1"
         android:layout_marginTop="40dp"
         android:id="@+id/hl1"
-        android:alpha="0.5"/>
+        android:alpha="0.5"
+        tools:ignore="ContentDescription" />
 
     <TextView
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
-        android:text="or"
+        android:text="@string/or_title"
         android:gravity="center"
         android:textStyle="bold"
         android:layout_below="@+id/hl1"
@@ -95,13 +121,13 @@
         <TextView
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
-            android:text="USE CUSTOM SETTINGS"
+            android:text="@string/custom_settings_title"
             android:textStyle="bold"
             android:gravity="center"
             android:layout_centerVertical="true"
             android:id="@+id/tvCustom"/>
 
-        <Switch
+        <androidx.appcompat.widget.SwitchCompat
             android:id="@+id/custom_settings_switch"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -5,6 +5,7 @@
     <string name="record_audio">Record Audio</string>
     <string name="high_definition">High Definition</string>
     <string name="standard_definition">Standard Definition</string>
+    <string name="max_file_label">Max File Size (k)</string>
 
     <string name="action_settings">Settings</string>
     <string name="title_activity_settings">Settings</string>
@@ -23,4 +24,13 @@
     <string name="key_video_encoder">key_video_encoder</string>
     <string name="key_audio_source">key_audio_source</string>
     <string name="key_output_format">key_output_format</string>
+    <string name="quick_settings_title">QUICK SETTINGS</string>
+    <string name="custom_settings_title">USE CUSTOM SETTINGS</string>
+    <string name="or_title">or</string>
+    <string name="max_file_hint">Blank == no max</string>
+    <string name="stop_recording_notification_message">Drag down to stop the recording</string>
+    <string name="stop_recording_notification_title">Recording your screen</string>
+    <string name="settings_not_supported_message">Some settings are not supported by your device</string>
+    <string name="max_file_size_reached_message">The file reached the designated max size</string>
+    <string name="general_recording_error_message">HBRecorderOnError - See Log</string>
 </resources>

--- a/app/src/main/res/xml/backup_descriptor.xml
+++ b/app/src/main/res/xml/backup_descriptor.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content>
+    <!-- Exclude specific shared preferences that contain GCM registration Id -->
+
+</full-backup-content>

--- a/hbrecorder/build.gradle
+++ b/hbrecorder/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 30
 
 
     defaultConfig {
         minSdkVersion 17
-        targetSdkVersion 29
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
 
@@ -26,8 +26,8 @@ android {
 dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
 
-    implementation 'androidx.appcompat:appcompat:1.1.0'
-    testImplementation 'junit:junit:4.12'
-    androidTestImplementation 'androidx.test:runner:1.2.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.2.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
+    testImplementation 'junit:junit:4.13.2'
+    androidTestImplementation 'androidx.test:runner:1.3.0'
+    androidTestImplementation 'androidx.test.espresso:espresso-core:3.3.0'
 }

--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/Constants.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/Constants.java
@@ -1,0 +1,15 @@
+package com.hbisoft.hbrecorder;
+
+public class Constants {
+    public final static String MAX_FILE_SIZE_KEY = "maxFileSize";
+    public final static String ERROR_REASON_KEY = "errorReason";
+    public final static String ERROR_KEY = "error";
+    public final static String ON_COMPLETE_KEY = "onComplete";
+    public final static String ON_START_KEY = "onStart";
+    public final static String ON_COMPLETE = "Uri was passed";
+    public final static int SETTINGS_ERROR = 38;
+    public final static int MAX_FILE_SIZE_REACHED_ERROR = 48;
+    public final static int GENERAL_ERROR = 100;
+    public final static int ON_START = 111;
+    public final static int NO_SPECIFIED_MAX_SIZE = 0;
+}

--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
@@ -35,16 +35,27 @@ import java.text.SimpleDateFormat;
 import java.util.Locale;
 import java.util.Objects;
 
+import static com.hbisoft.hbrecorder.Constants.ERROR_KEY;
+import static com.hbisoft.hbrecorder.Constants.ERROR_REASON_KEY;
+import static com.hbisoft.hbrecorder.Constants.MAX_FILE_SIZE_REACHED_ERROR;
+import static com.hbisoft.hbrecorder.Constants.MAX_FILE_SIZE_KEY;
+import static com.hbisoft.hbrecorder.Constants.NO_SPECIFIED_MAX_SIZE;
+import static com.hbisoft.hbrecorder.Constants.ON_COMPLETE;
+import static com.hbisoft.hbrecorder.Constants.ON_COMPLETE_KEY;
+import static com.hbisoft.hbrecorder.Constants.ON_START;
+import static com.hbisoft.hbrecorder.Constants.ON_START_KEY;
+import static com.hbisoft.hbrecorder.Constants.SETTINGS_ERROR;
+
 /**
  * Created by HBiSoft on 13 Aug 2019
  * Copyright (c) 2019 . All rights reserved.
  */
 
-@SuppressWarnings("deprecation")
 public class ScreenRecordService extends Service {
 
     private static final String TAG = "ScreenRecordService";
-
+    private long maxFileSize = NO_SPECIFIED_MAX_SIZE;
+    private boolean hasMaxFileBeenReached = false;
     private int mScreenWidth;
     private int mScreenHeight;
     private int mScreenDensity;
@@ -93,7 +104,9 @@ public class ScreenRecordService extends Service {
         //Start Recording
         else {
             //Get intent extras
+            hasMaxFileBeenReached = false;
             mIntent = intent;
+            maxFileSize = intent.getLongExtra(MAX_FILE_SIZE_KEY, NO_SPECIFIED_MAX_SIZE);
             byte[] notificationSmallIcon = intent.getByteArrayExtra("notificationSmallBitmap");
             String notificationTitle = intent.getStringExtra("notificationTitle");
             String notificationDescription = intent.getStringExtra("notificationDescription");
@@ -137,7 +150,7 @@ public class ScreenRecordService extends Service {
             audioSamplingRate = intent.getIntExtra("audioSamplingRate", 44100);
             String outputFormat = intent.getStringExtra("outputFormat");
             if (outputFormat != null) {
-                setOutputformatAsInt(outputFormat);
+                setOutputFormatAsInt(outputFormat);
             }
 
             isCustomSettingsEnabled = intent.getBooleanExtra("enableCustomSettings", false);
@@ -156,11 +169,11 @@ public class ScreenRecordService extends Service {
             }
             //Set notification title if developer did not
             if (notificationTitle == null || notificationTitle.equals("")) {
-                notificationTitle = "Recording your screen";
+                notificationTitle = getString(R.string.stop_recording_notification_title);
             }
             //Set notification description if developer did not
             if (notificationDescription == null || notificationDescription.equals("")) {
-                notificationDescription = "Drag down to stop the recording";
+                notificationDescription = getString(R.string.stop_recording_notification_message);
             }
 
             //Notification
@@ -212,7 +225,7 @@ public class ScreenRecordService extends Service {
             } catch (Exception e) {
                 ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("errorReason", Log.getStackTraceString(e));
+                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -224,7 +237,7 @@ public class ScreenRecordService extends Service {
             } catch (Exception e) {
                 ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("errorReason", Log.getStackTraceString(e));
+                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -236,7 +249,7 @@ public class ScreenRecordService extends Service {
             } catch (Exception e) {
                 ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("errorReason", Log.getStackTraceString(e));
+                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -244,13 +257,34 @@ public class ScreenRecordService extends Service {
 
             mMediaRecorder.setOnErrorListener(new MediaRecorder.OnErrorListener() {
                 @Override
-                public void onError(MediaRecorder mediaRecorder, int i, int i1) {
+                public void onError(MediaRecorder mediaRecorder, int what, int extra) {
+                    if ( what == 268435556 && hasMaxFileBeenReached) {
+                        // Benign error b/c recording is too short and has no frames. See SO: https://stackoverflow.com/questions/40616466/mediarecorder-stop-failed-1007
+                        return;
+                    }
                     ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                     Bundle bundle = new Bundle();
-                    bundle.putString("error", "38");
-                    bundle.putString("errorReason", String.valueOf(i));
+                    bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
+                    bundle.putString(ERROR_REASON_KEY, String.valueOf(what));
                     if (receiver != null) {
                         receiver.send(Activity.RESULT_OK, bundle);
+                    }
+                }
+            });
+
+            mMediaRecorder.setOnInfoListener(new MediaRecorder.OnInfoListener() {
+                @Override
+                public void onInfo(MediaRecorder mr, int what, int extra) {
+                    if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED) {
+                        hasMaxFileBeenReached = true;
+                        Log.i(TAG,String.format(Locale.US,"onInfoListen what : %d | extra %d", what, extra));
+                        ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                        Bundle bundle = new Bundle();
+                        bundle.putInt(ERROR_KEY, MAX_FILE_SIZE_REACHED_ERROR);
+                        bundle.putString(ERROR_REASON_KEY, getString(R.string.max_file_reached));
+                        if (receiver != null) {
+                            receiver.send(Activity.RESULT_OK, bundle);
+                        }
                     }
                 }
             });
@@ -260,7 +294,7 @@ public class ScreenRecordService extends Service {
                 mMediaRecorder.start();
                 ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("onStart", "111");
+                bundle.putInt(ON_START_KEY, ON_START);
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -268,8 +302,8 @@ public class ScreenRecordService extends Service {
                 // From the tests I've done, this can happen if another application is using the mic or if an unsupported video encoder was selected
                 ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("error", "38");
-                bundle.putString("errorReason", Log.getStackTraceString(e));
+                bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
+                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -294,16 +328,13 @@ public class ScreenRecordService extends Service {
 
     //Set output format as int based on what developer has provided
     //It is important to provide one of the following and nothing else.
-    private void setOutputformatAsInt(String outputFormat) {
+    private void setOutputFormatAsInt(String outputFormat) {
         switch (outputFormat) {
             case "DEFAULT":
                 outputFormatAsInt = 0;
                 break;
             case "THREE_GPP":
                 outputFormatAsInt = 1;
-                break;
-            case "MPEG_4":
-                outputFormatAsInt = 2;
                 break;
             case "AMR_NB":
                 outputFormatAsInt = 3;
@@ -323,6 +354,7 @@ public class ScreenRecordService extends Service {
             case "OGG":
                 outputFormatAsInt = 11;
                 break;
+            case "MPEG_4":
             default:
                 outputFormatAsInt = 2;
         }
@@ -455,7 +487,7 @@ public class ScreenRecordService extends Service {
             } catch (Exception e) {
                 ResultReceiver receiver = mIntent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                 Bundle bundle = new Bundle();
-                bundle.putString("errorReason", Log.getStackTraceString(e));
+                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                 if (receiver != null) {
                     receiver.send(Activity.RESULT_OK, bundle);
                 }
@@ -478,6 +510,10 @@ public class ScreenRecordService extends Service {
             mMediaRecorder.setVideoFrameRate(videoFrameRate);
         }
 
+        // Catch approaching file limit
+        if ( maxFileSize > NO_SPECIFIED_MAX_SIZE) {
+            mMediaRecorder.setMaxFileSize(maxFileSize); // in bytes
+        }
 
         mMediaRecorder.prepare();
 
@@ -500,7 +536,7 @@ public class ScreenRecordService extends Service {
     private void callOnComplete() {
         ResultReceiver receiver = mIntent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
         Bundle bundle = new Bundle();
-        bundle.putString("onComplete", "Uri was passed");
+        bundle.putString(ON_COMPLETE_KEY, ON_COMPLETE);
         if (receiver != null) {
             receiver.send(Activity.RESULT_OK, bundle);
         }

--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
@@ -534,11 +534,13 @@ public class ScreenRecordService extends Service {
     }
 
     private void callOnComplete() {
-        ResultReceiver receiver = mIntent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-        Bundle bundle = new Bundle();
-        bundle.putString(ON_COMPLETE_KEY, ON_COMPLETE);
-        if (receiver != null) {
-            receiver.send(Activity.RESULT_OK, bundle);
+        if ( mIntent != null ) {
+            ResultReceiver receiver = mIntent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+            Bundle bundle = new Bundle();
+            bundle.putString(ON_COMPLETE_KEY, ON_COMPLETE);
+            if (receiver != null) {
+                receiver.send(Activity.RESULT_OK, bundle);
+            }
         }
     }
 

--- a/hbrecorder/src/main/res/values/strings.xml
+++ b/hbrecorder/src/main/res/values/strings.xml
@@ -1,3 +1,6 @@
 <resources>
     <string name="app_name">HBRecorder</string>
+    <string name="max_file_reached">File size max has been reached.</string>
+    <string name="stop_recording_notification_message">Drag down to stop the recording</string>
+    <string name="stop_recording_notification_title">Recording your screen</string>
 </resources>


### PR DESCRIPTION
This update performs three major items:

1. Implements a way to specify a maximum file size in K bytes. If so specified, then when that size is reached the recording will automatically stop and close the file - it is considered a type of "passive error" condition. See the sample app for sample usage.
2. Started the process of consolidating use of constants (i.e. "38", "100", "111") into a centralized file, and utilizing string constants for string values, and int constants for error codes (i.e. string "38" became an int 38 rather than using it as a string in one place and an int value in another).
3. Updated the target SDK to 30 and making various other Android lint suggested changes in both the sample app and the hbrecorder module.