### PR TITLE
fix!: fixed memory leak due to unnecessary Activity reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ protected void onActivityResult(int requestCode, int resultCode, Intent data) {
     if (requestCode == SCREEN_RECORD_REQUEST_CODE) {
         if (resultCode == RESULT_OK) {
             //Start screen recording
-            hbRecorder.startScreenRecording(data, resultCode, this);
+            hbRecorder.startScreenRecording(data, resultCode);
 
         }
     }

--- a/app/src/main/java/com/hbisoft/hbrecorderexample/MainActivity.java
+++ b/app/src/main/java/com/hbisoft/hbrecorderexample/MainActivity.java
@@ -596,7 +596,7 @@ public class MainActivity extends AppCompatActivity implements HBRecorderListene
                     //Set file path or Uri depending on SDK version
                     setOutputPath();
                     //Start screen recording
-                    hbRecorder.startScreenRecording(data, resultCode, this);
+                    hbRecorder.startScreenRecording(data, resultCode);
 
                 }
             }

--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/FileObserver.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/FileObserver.java
@@ -6,6 +6,8 @@ import java.util.List;
 import java.util.Stack;
 
 import android.app.Activity;
+import android.os.Handler;
+import android.os.Looper;
 
 
 class FileObserver extends android.os.FileObserver {
@@ -13,15 +15,13 @@ class FileObserver extends android.os.FileObserver {
     private List<SingleFileObserver> mObservers;
     private final String mPath;
     private final int mMask;
-    private final Activity activity;
     private final MyListener ml;
 
-    FileObserver(String path, Activity activity, MyListener ml) {
+    FileObserver(String path, MyListener ml) {
         super(path, ALL_EVENTS);
         mPath = path;
         mMask = ALL_EVENTS;
 
-        this.activity = activity;
         this.ml = ml;
 
     }
@@ -68,7 +68,7 @@ class FileObserver extends android.os.FileObserver {
     @Override
     public void onEvent(int event, final String path) {
         if (event == android.os.FileObserver.CLOSE_WRITE) {
-            activity.runOnUiThread(new Runnable() {
+            new Handler(Looper.getMainLooper()).post(new Runnable() {
                 public void run() {
                     ml.callback();
                 }

--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/HBRecorder.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/HBRecorder.java
@@ -17,6 +17,7 @@ import androidx.annotation.DrawableRes;
 import androidx.annotation.RequiresApi;
 
 import android.os.Handler;
+import android.os.Looper;
 import android.os.ResultReceiver;
 import android.util.DisplayMetrics;
 import android.util.Log;
@@ -47,7 +48,6 @@ public class HBRecorder implements MyListener {
     private int resultCode;
     private boolean isAudioEnabled = true;
     private boolean isVideoHDEnabled = true;
-    private Activity activity;
     private String outputPath;
     private String fileName;
     private String notificationTitle;
@@ -211,9 +211,8 @@ public class HBRecorder implements MyListener {
     }
 
     /*Start screen recording*/
-    public void startScreenRecording(Intent data, int resultCode, Activity activity) {
+    public void startScreenRecording(Intent data, int resultCode) {
         this.resultCode = resultCode;
-        this.activity = activity;
         startService(data);
     }
 
@@ -300,9 +299,9 @@ public class HBRecorder implements MyListener {
                 if (outputPath != null) {
                     File file = new File(outputPath);
                     String parent = file.getParent();
-                    observer = new FileObserver(parent, activity, HBRecorder.this);
+                    observer = new FileObserver(parent, HBRecorder.this);
                 } else {
-                    observer = new FileObserver(String.valueOf(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)), activity, HBRecorder.this);
+                    observer = new FileObserver(String.valueOf(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES)), HBRecorder.this);
                 }
                 observer.startWatching();
             }
@@ -405,7 +404,8 @@ public class HBRecorder implements MyListener {
                 onTick(0);
                 // Since the timer is running on a different thread
                 // UI chances should be called from the UI Thread
-                activity.runOnUiThread(new Runnable() {
+
+                new Handler(Looper.getMainLooper()).post(new Runnable() {
                     @Override
                     public void run() {
                         try {


### PR DESCRIPTION
Fixes #117 
API change: Activity argument is no longer required in `HBRecorder.startScreenRecording()`