### PR TITLE
Fix: Null Pointer Exception

### DIFF
--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/ScreenRecordService.java
@@ -91,246 +91,248 @@ public class ScreenRecordService extends Service {
         boolean isAction = false;
 
         //Check if there was an action called
-        if (intent != null && intent.getAction() != null){
-            isAction = true;
-        }
+        if (intent != null) {
 
-        //If there was an action, check what action it was
-        //Called when recording should be paused or resumed
-        if (isAction){
-            //Pause Recording
-            if (intent.getAction().equals("pause")) {
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    pauseRecording();
-                }
-            }
-            //Resume Recording
-            else if (intent.getAction().equals("resume")){
-                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
-                    resumeRecording();
-                }
-            }
-        }
-        //Start Recording
-        else {
-            //Get intent extras
-            hasMaxFileBeenReached = false;
-            mIntent = intent;
-            maxFileSize = intent.getLongExtra(MAX_FILE_SIZE_KEY, NO_SPECIFIED_MAX_SIZE);
-            byte[] notificationSmallIcon = intent.getByteArrayExtra("notificationSmallBitmap");
-            int notificationSmallVector = intent.getIntExtra("notificationSmallVector", 0);
-            String notificationTitle = intent.getStringExtra("notificationTitle");
-            String notificationDescription = intent.getStringExtra("notificationDescription");
-            String notificationButtonText = intent.getStringExtra("notificationButtonText");
-            orientationHint = intent.getIntExtra("orientation", 400);
-            mResultCode = intent.getIntExtra("code", -1);
-            mResultData = intent.getParcelableExtra("data");
-            mScreenWidth = intent.getIntExtra("width", 0);
-            mScreenHeight = intent.getIntExtra("height", 0);
-
-            if (intent.getStringExtra("mUri") != null) {
-                returnedUri = Uri.parse(intent.getStringExtra("mUri"));
+            if (intent.getAction() != null) {
+                isAction = true;
             }
 
-            if (mScreenHeight == 0 || mScreenWidth == 0) {
-                HBRecorderCodecInfo hbRecorderCodecInfo = new HBRecorderCodecInfo();
-                hbRecorderCodecInfo.setContext(this);
-                mScreenHeight = hbRecorderCodecInfo.getMaxSupportedHeight();
-                mScreenWidth = hbRecorderCodecInfo.getMaxSupportedWidth();
-            }
-
-            mScreenDensity = intent.getIntExtra("density", 1);
-            isVideoHD = intent.getBooleanExtra("quality", true);
-            isAudioEnabled = intent.getBooleanExtra("audio", true);
-            path = intent.getStringExtra("path");
-            name = intent.getStringExtra("fileName");
-            String audioSource = intent.getStringExtra("audioSource");
-            String videoEncoder = intent.getStringExtra("videoEncoder");
-            videoFrameRate = intent.getIntExtra("videoFrameRate", 30);
-            videoBitrate = intent.getIntExtra("videoBitrate", 40000000);
-
-            if (audioSource != null) {
-                setAudioSourceAsInt(audioSource);
-            }
-            if (videoEncoder != null) {
-                setvideoEncoderAsInt(videoEncoder);
-            }
-
-            filePath = name;
-            audioBitrate = intent.getIntExtra("audioBitrate", 128000);
-            audioSamplingRate = intent.getIntExtra("audioSamplingRate", 44100);
-            String outputFormat = intent.getStringExtra("outputFormat");
-            if (outputFormat != null) {
-                setOutputFormatAsInt(outputFormat);
-            }
-
-            isCustomSettingsEnabled = intent.getBooleanExtra("enableCustomSettings", false);
-
-            //Set notification notification button text if developer did not
-            if (notificationButtonText == null) {
-                notificationButtonText = "STOP RECORDING";
-            }
-            //Set notification bitrate if developer did not
-            if (audioBitrate == 0) {
-                audioBitrate = 128000;
-            }
-            //Set notification sampling rate if developer did not
-            if (audioSamplingRate == 0) {
-                audioSamplingRate = 44100;
-            }
-            //Set notification title if developer did not
-            if (notificationTitle == null || notificationTitle.equals("")) {
-                notificationTitle = getString(R.string.stop_recording_notification_title);
-            }
-            //Set notification description if developer did not
-            if (notificationDescription == null || notificationDescription.equals("")) {
-                notificationDescription = getString(R.string.stop_recording_notification_message);
-            }
-
-            //Notification
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-                String channelId = "001";
-                String channelName = "RecordChannel";
-                NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_NONE);
-                channel.setLightColor(Color.BLUE);
-                channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
-                NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
-                if (manager != null) {
-                    manager.createNotificationChannel(channel);
-                    Notification notification;
-
-                    Intent myIntent = new Intent(this, NotificationReceiver.class);
-                    PendingIntent pendingIntent;
-
-                    if (Build.VERSION.SDK_INT >= 31){
-                        pendingIntent = PendingIntent.getBroadcast(this, 0, myIntent, PendingIntent.FLAG_IMMUTABLE);
-                    }else{
-                        pendingIntent = PendingIntent.getBroadcast(this, 0, myIntent, 0);
-
+            //If there was an action, check what action it was
+            //Called when recording should be paused or resumed
+            if (isAction) {
+                //Pause Recording
+                if (intent.getAction().equals("pause")) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        pauseRecording();
                     }
-
-                    Notification.Action action = new Notification.Action.Builder(
-                            Icon.createWithResource(this, android.R.drawable.presence_video_online),
-                            notificationButtonText,
-                            pendingIntent).build();
-
-                    if (notificationSmallIcon != null) {
-                        Bitmap bmp = BitmapFactory.decodeByteArray(notificationSmallIcon, 0, notificationSmallIcon.length);
-                        //Modify notification badge
-                        notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(Icon.createWithBitmap(bmp)).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
-
-                    } else if (notificationSmallVector != 0){
-                        notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(notificationSmallVector).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
+                }
+                //Resume Recording
+                else if (intent.getAction().equals("resume")) {
+                    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.N) {
+                        resumeRecording();
                     }
+                }
+            }
+            //Start Recording
+            else {
+                //Get intent extras
+                hasMaxFileBeenReached = false;
+                mIntent = intent;
+                maxFileSize = intent.getLongExtra(MAX_FILE_SIZE_KEY, NO_SPECIFIED_MAX_SIZE);
+                byte[] notificationSmallIcon = intent.getByteArrayExtra("notificationSmallBitmap");
+                int notificationSmallVector = intent.getIntExtra("notificationSmallVector", 0);
+                String notificationTitle = intent.getStringExtra("notificationTitle");
+                String notificationDescription = intent.getStringExtra("notificationDescription");
+                String notificationButtonText = intent.getStringExtra("notificationButtonText");
+                orientationHint = intent.getIntExtra("orientation", 400);
+                mResultCode = intent.getIntExtra("code", -1);
+                mResultData = intent.getParcelableExtra("data");
+                mScreenWidth = intent.getIntExtra("width", 0);
+                mScreenHeight = intent.getIntExtra("height", 0);
 
-                    else {
-                        //Modify notification badge
-                        notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(R.drawable.icon).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
+                if (intent.getStringExtra("mUri") != null) {
+                    returnedUri = Uri.parse(intent.getStringExtra("mUri"));
+                }
+
+                if (mScreenHeight == 0 || mScreenWidth == 0) {
+                    HBRecorderCodecInfo hbRecorderCodecInfo = new HBRecorderCodecInfo();
+                    hbRecorderCodecInfo.setContext(this);
+                    mScreenHeight = hbRecorderCodecInfo.getMaxSupportedHeight();
+                    mScreenWidth = hbRecorderCodecInfo.getMaxSupportedWidth();
+                }
+
+                mScreenDensity = intent.getIntExtra("density", 1);
+                isVideoHD = intent.getBooleanExtra("quality", true);
+                isAudioEnabled = intent.getBooleanExtra("audio", true);
+                path = intent.getStringExtra("path");
+                name = intent.getStringExtra("fileName");
+                String audioSource = intent.getStringExtra("audioSource");
+                String videoEncoder = intent.getStringExtra("videoEncoder");
+                videoFrameRate = intent.getIntExtra("videoFrameRate", 30);
+                videoBitrate = intent.getIntExtra("videoBitrate", 40000000);
+
+                if (audioSource != null) {
+                    setAudioSourceAsInt(audioSource);
+                }
+                if (videoEncoder != null) {
+                    setvideoEncoderAsInt(videoEncoder);
+                }
+
+                filePath = name;
+                audioBitrate = intent.getIntExtra("audioBitrate", 128000);
+                audioSamplingRate = intent.getIntExtra("audioSamplingRate", 44100);
+                String outputFormat = intent.getStringExtra("outputFormat");
+                if (outputFormat != null) {
+                    setOutputFormatAsInt(outputFormat);
+                }
+
+                isCustomSettingsEnabled = intent.getBooleanExtra("enableCustomSettings", false);
+
+                //Set notification notification button text if developer did not
+                if (notificationButtonText == null) {
+                    notificationButtonText = "STOP RECORDING";
+                }
+                //Set notification bitrate if developer did not
+                if (audioBitrate == 0) {
+                    audioBitrate = 128000;
+                }
+                //Set notification sampling rate if developer did not
+                if (audioSamplingRate == 0) {
+                    audioSamplingRate = 44100;
+                }
+                //Set notification title if developer did not
+                if (notificationTitle == null || notificationTitle.equals("")) {
+                    notificationTitle = getString(R.string.stop_recording_notification_title);
+                }
+                //Set notification description if developer did not
+                if (notificationDescription == null || notificationDescription.equals("")) {
+                    notificationDescription = getString(R.string.stop_recording_notification_message);
+                }
+
+                //Notification
+                if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                    String channelId = "001";
+                    String channelName = "RecordChannel";
+                    NotificationChannel channel = new NotificationChannel(channelId, channelName, NotificationManager.IMPORTANCE_NONE);
+                    channel.setLightColor(Color.BLUE);
+                    channel.setLockscreenVisibility(Notification.VISIBILITY_PRIVATE);
+                    NotificationManager manager = (NotificationManager) getSystemService(Context.NOTIFICATION_SERVICE);
+                    if (manager != null) {
+                        manager.createNotificationChannel(channel);
+                        Notification notification;
+
+                        Intent myIntent = new Intent(this, NotificationReceiver.class);
+                        PendingIntent pendingIntent;
+
+                        if (Build.VERSION.SDK_INT >= 31) {
+                            pendingIntent = PendingIntent.getBroadcast(this, 0, myIntent, PendingIntent.FLAG_IMMUTABLE);
+                        } else {
+                            pendingIntent = PendingIntent.getBroadcast(this, 0, myIntent, 0);
+
+                        }
+
+                        Notification.Action action = new Notification.Action.Builder(
+                                Icon.createWithResource(this, android.R.drawable.presence_video_online),
+                                notificationButtonText,
+                                pendingIntent).build();
+
+                        if (notificationSmallIcon != null) {
+                            Bitmap bmp = BitmapFactory.decodeByteArray(notificationSmallIcon, 0, notificationSmallIcon.length);
+                            //Modify notification badge
+                            notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(Icon.createWithBitmap(bmp)).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
+
+                        } else if (notificationSmallVector != 0) {
+                            notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(notificationSmallVector).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
+                        } else {
+                            //Modify notification badge
+                            notification = new Notification.Builder(getApplicationContext(), channelId).setOngoing(true).setSmallIcon(R.drawable.icon).setContentTitle(notificationTitle).setContentText(notificationDescription).addAction(action).build();
+                        }
+                        startForeground(101, notification);
                     }
-                    startForeground(101, notification);
+                } else {
+                    startForeground(101, new Notification());
                 }
-            } else {
-                startForeground(101, new Notification());
-            }
 
 
-            if (returnedUri == null) {
-                if (path == null) {
-                    path = String.valueOf(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES));
-                }
-            }
-
-            //Init MediaRecorder
-            try {
-                initRecorder();
-            } catch (Exception e) {
-                ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-                Bundle bundle = new Bundle();
-                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
-                if (receiver != null) {
-                    receiver.send(Activity.RESULT_OK, bundle);
-                }
-            }
-
-            //Init MediaProjection
-            try {
-                initMediaProjection();
-            } catch (Exception e) {
-                ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-                Bundle bundle = new Bundle();
-                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
-                if (receiver != null) {
-                    receiver.send(Activity.RESULT_OK, bundle);
-                }
-            }
-
-            //Init VirtualDisplay
-            try {
-                initVirtualDisplay();
-            } catch (Exception e) {
-                ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-                Bundle bundle = new Bundle();
-                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
-                if (receiver != null) {
-                    receiver.send(Activity.RESULT_OK, bundle);
-                }
-            }
-
-            mMediaRecorder.setOnErrorListener(new MediaRecorder.OnErrorListener() {
-                @Override
-                public void onError(MediaRecorder mediaRecorder, int what, int extra) {
-                    if ( what == 268435556 && hasMaxFileBeenReached) {
-                        // Benign error b/c recording is too short and has no frames. See SO: https://stackoverflow.com/questions/40616466/mediarecorder-stop-failed-1007
-                        return;
+                if (returnedUri == null) {
+                    if (path == null) {
+                        path = String.valueOf(Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES));
                     }
+                }
+
+                //Init MediaRecorder
+                try {
+                    initRecorder();
+                } catch (Exception e) {
                     ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                     Bundle bundle = new Bundle();
-                    bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
-                    bundle.putString(ERROR_REASON_KEY, String.valueOf(what));
+                    bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
                     if (receiver != null) {
                         receiver.send(Activity.RESULT_OK, bundle);
                     }
                 }
-            });
 
-            mMediaRecorder.setOnInfoListener(new MediaRecorder.OnInfoListener() {
-                @Override
-                public void onInfo(MediaRecorder mr, int what, int extra) {
-                    if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED) {
-                        hasMaxFileBeenReached = true;
-                        Log.i(TAG,String.format(Locale.US,"onInfoListen what : %d | extra %d", what, extra));
+                //Init MediaProjection
+                try {
+                    initMediaProjection();
+                } catch (Exception e) {
+                    ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                    Bundle bundle = new Bundle();
+                    bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
+                    if (receiver != null) {
+                        receiver.send(Activity.RESULT_OK, bundle);
+                    }
+                }
+
+                //Init VirtualDisplay
+                try {
+                    initVirtualDisplay();
+                } catch (Exception e) {
+                    ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                    Bundle bundle = new Bundle();
+                    bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
+                    if (receiver != null) {
+                        receiver.send(Activity.RESULT_OK, bundle);
+                    }
+                }
+
+                mMediaRecorder.setOnErrorListener(new MediaRecorder.OnErrorListener() {
+                    @Override
+                    public void onError(MediaRecorder mediaRecorder, int what, int extra) {
+                        if (what == 268435556 && hasMaxFileBeenReached) {
+                            // Benign error b/c recording is too short and has no frames. See SO: https://stackoverflow.com/questions/40616466/mediarecorder-stop-failed-1007
+                            return;
+                        }
                         ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
                         Bundle bundle = new Bundle();
-                        bundle.putInt(ERROR_KEY, MAX_FILE_SIZE_REACHED_ERROR);
-                        bundle.putString(ERROR_REASON_KEY, getString(R.string.max_file_reached));
+                        bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
+                        bundle.putString(ERROR_REASON_KEY, String.valueOf(what));
                         if (receiver != null) {
                             receiver.send(Activity.RESULT_OK, bundle);
                         }
                     }
-                }
-            });
+                });
 
-            //Start Recording
-            try {
-                mMediaRecorder.start();
-                ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-                Bundle bundle = new Bundle();
-                bundle.putInt(ON_START_KEY, ON_START);
-                if (receiver != null) {
-                    receiver.send(Activity.RESULT_OK, bundle);
-                }
-            } catch (Exception e) {
-                // From the tests I've done, this can happen if another application is using the mic or if an unsupported video encoder was selected
-                ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
-                Bundle bundle = new Bundle();
-                bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
-                bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
-                if (receiver != null) {
-                    receiver.send(Activity.RESULT_OK, bundle);
+                mMediaRecorder.setOnInfoListener(new MediaRecorder.OnInfoListener() {
+                    @Override
+                    public void onInfo(MediaRecorder mr, int what, int extra) {
+                        if (what == MediaRecorder.MEDIA_RECORDER_INFO_MAX_FILESIZE_REACHED) {
+                            hasMaxFileBeenReached = true;
+                            Log.i(TAG, String.format(Locale.US, "onInfoListen what : %d | extra %d", what, extra));
+                            ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                            Bundle bundle = new Bundle();
+                            bundle.putInt(ERROR_KEY, MAX_FILE_SIZE_REACHED_ERROR);
+                            bundle.putString(ERROR_REASON_KEY, getString(R.string.max_file_reached));
+                            if (receiver != null) {
+                                receiver.send(Activity.RESULT_OK, bundle);
+                            }
+                        }
+                    }
+                });
+
+                //Start Recording
+                try {
+                    mMediaRecorder.start();
+                    ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                    Bundle bundle = new Bundle();
+                    bundle.putInt(ON_START_KEY, ON_START);
+                    if (receiver != null) {
+                        receiver.send(Activity.RESULT_OK, bundle);
+                    }
+                } catch (Exception e) {
+                    // From the tests I've done, this can happen if another application is using the mic or if an unsupported video encoder was selected
+                    ResultReceiver receiver = intent.getParcelableExtra(ScreenRecordService.BUNDLED_LISTENER);
+                    Bundle bundle = new Bundle();
+                    bundle.putInt(ERROR_KEY, SETTINGS_ERROR);
+                    bundle.putString(ERROR_REASON_KEY, Log.getStackTraceString(e));
+                    if (receiver != null) {
+                        receiver.send(Activity.RESULT_OK, bundle);
+                    }
                 }
             }
+        } else {
+            stopSelf(startId);
         }
-
 
         return Service.START_STICKY;
     }


### PR DESCRIPTION
Fixes #127 

Issue is reproducible when service/process is potentially killed by the system and since `ScreenRecordingService.onStartCommand()` is returning `START_STICKY`, and if the service is in the started state, system will try to recreate the service. But, it will not retain intent. So, intent will be null in that case and 
`Attempt to invoke virtual method 'long android.content.Intent.getLongExtra(java.lang.String, long)' on a null object reference` will occur.

In that case, stopping service is called to avoid any other potential issue. 

Also, consider returning START_REDELIVER_INTENT instead of START_STICKY, so Intent is retained after a service restart.

## Changes: 
Added null check on Intent
Stop Service if Intent is null