### PR TITLE
Fixed Issue Android 14 compatibility #166

### DIFF
--- a/hbrecorder/src/main/java/com/hbisoft/hbrecorder/Countdown.java
+++ b/hbrecorder/src/main/java/com/hbisoft/hbrecorder/Countdown.java
@@ -23,7 +23,7 @@ public abstract class Countdown extends Timer {
 
     public void start() {
         wasStarted = true;
-        this.scheduleAtFixedRate(task, delay, interval);
+        this.schedule(task, delay, interval);
     }
 
     public void stop() {


### PR DESCRIPTION
Implemented a fix for an error occurring on Android 14 when using the library for screen recording. The error was:
Recording error - Code: 100, Reason: java.lang.IllegalStateException: Must register a callback before starting capture, to manage resources in response to MediaProjection states.
Solution:

Adjusted the sequence of operations to ensure that a callback is registered before starting the capture.
Ensured compliance with the new MediaProjection resource management requirements introduced in Android 14.
Impact:

This fix resolves the recording issue on Android 14, maintaining compatibility across all supported Android versions.
Users targeting SDK 34 can now perform screen recordings without encountering the IllegalStateException.